### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/flir_adk_ethernet/EthernetCamera.cpp
+++ b/src/flir_adk_ethernet/EthernetCamera.cpp
@@ -240,7 +240,7 @@ bool EthernetCamera::setROI(int xOffset, int yOffset, int width, int height) {
             _width, _height, _xOffset, _yOffset);
         return true;
     } catch (Spinnaker::Exception e) {
-        ROS_ERROR(e.what());
+        ROS_ERROR("%s", e.what());
 
         widthNode->SetValue(8);
         heightNode->SetValue(8);
@@ -451,7 +451,7 @@ bool EthernetCamera::setNodeValue(std::string nodeName, std::string value) {
             }
         }
     } catch(Spinnaker::Exception e) {
-        ROS_ERROR(e.what());
+        ROS_ERROR("%s", e.what());
     }
     
     startCapture();
@@ -509,7 +509,7 @@ void EthernetCamera::stopCapture() {
         _isStreaming = false;
         _pCam->EndAcquisition();
     } catch(Spinnaker::Exception e) {
-        ROS_ERROR(e.what());
+        ROS_ERROR("%s", e.what());
     }
 }
 

--- a/src/flir_adk_ethernet/ImageEventHandler.cpp
+++ b/src/flir_adk_ethernet/ImageEventHandler.cpp
@@ -42,8 +42,8 @@ void ImageEventHandler::Init() {
 }
 
 ImageInfo ImageEventHandler::GetImageInfo() {
-    return ImageInfo {m_resultImage->GetWidth(), m_resultImage->GetHeight(),
-                m_resultImage->GetBufferSize()};
+    return ImageInfo {(int)m_resultImage->GetWidth(), (int)m_resultImage->GetHeight(),
+                (int)m_resultImage->GetBufferSize()};
 }
 
 // int framesPerSecond = 0;


### PR DESCRIPTION
- warning: format not a string literal and no format arguments [-Wformat-security]
- warning: narrowing conversion ... from ‘size_t {aka long unsigned int}’ to ‘int32_t {aka int}’ inside { } [-Wnarrowing]